### PR TITLE
Add basic .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*   text=auto


### PR DESCRIPTION
If working on Windows, some editors automatically convert the LF line endings to the Windows CRLF ending.
This change lets git automatically convert all file endings back to LF as soon as they are added/stashed.